### PR TITLE
Upgrade from Java 8 to Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.4.RELEASE</version>
+		<version>2.3.12.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.coding.exercise</groupId>
@@ -15,7 +15,7 @@
 	<description>Bank App Spring Boot Project</description>
 
 	<properties>
-		<java.version>1.8</java.version>
+		<java.version>11</java.version>
 	</properties>
 
 	<dependencies>
@@ -49,18 +49,13 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>io.springfox</groupId>
-			<artifactId>springfox-swagger2</artifactId>
-			<version>2.9.2</version>
-		</dependency>
-		<dependency>
-			<groupId>io.springfox</groupId>
-			<artifactId>springfox-swagger-ui</artifactId>
-			<version>2.9.2</version>
-		</dependency>		
+		<optional>true</optional>
+	</dependency>
+	<dependency>
+		<groupId>io.springfox</groupId>
+		<artifactId>springfox-boot-starter</artifactId>
+		<version>3.0.0</version>
+	</dependency>		
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>


### PR DESCRIPTION
# Upgrade from Java 8 to Java 11

## Summary
This PR upgrades the BankApp Spring Boot application from Java 8 to Java 11 as requested. The changes include:

- **Java version**: Updated from `1.8` to `11` in pom.xml
- **Spring Boot**: Upgraded from `2.1.4.RELEASE` to `2.3.12.RELEASE` for better Java 11 compatibility
- **Swagger/OpenAPI**: Migrated from separate Springfox 2.x dependencies (`springfox-swagger2` 2.9.2 + `springfox-swagger-ui` 2.9.2) to consolidated `springfox-boot-starter` 3.0.0
- **Lombok**: Will automatically update to Java 11-compatible version via Spring Boot parent

⚠️ **Important**: I was unable to test these changes locally because the development environment has Java 8 installed. The build failed locally with "invalid target release: 11". CI will be the first real verification that the application compiles and runs correctly with Java 11.

## Review & Testing Checklist for Human

**Risk Level**: 🟡 Medium - Major dependency upgrades without local testing

- [ ] **Verify CI build passes** - The local environment couldn't compile with Java 11, so CI is the first validation point
- [ ] **Check Swagger UI accessibility** - Springfox 3.0.0 may have changed the Swagger UI URL from `/swagger-ui.html` to `/swagger-ui/index.html` or similar
- [ ] **Test application startup** - Verify the app starts successfully with `mvn spring-boot:run` in a Java 11 environment
- [ ] **Smoke test API endpoints** - Test a few key endpoints (customer creation, account operations) to ensure Spring Boot 2.3 changes didn't break anything
- [ ] **Verify H2 console access** - Confirm the H2 database console at `/h2-console/` still works with the Spring Boot upgrade

### Recommended Test Plan
1. Start the application: `mvn spring-boot:run`
2. Access Swagger UI (try both `/swagger-ui.html` and `/swagger-ui/index.html`)
3. Test a few API operations through Swagger UI or curl
4. Verify H2 console at `http://localhost:8989/bank-api/h2-console/`
5. Run tests: `mvn test`

### Notes
- The Springfox 3.0.0 upgrade may require configuration changes in `ApplicationConfig.java` if the Swagger UI is not accessible at the expected URL
- Spring Boot 2.1 → 2.3 is a significant jump that could introduce breaking changes in security, JPA, or actuator endpoints
- No source code modifications were made as the task indicated they weren't necessary, but this should be validated

---
**Link to Devin run**: https://app.devin.ai/sessions/9fbaf8ef8f6c4ed4996d9eb5c13593bc  
**Requested by**: Stephen Cornwell (@stephencornwell)