### PR TITLE
Upgrade from Java 8 to Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.4.RELEASE</version>
+		<version>2.3.12.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.coding.exercise</groupId>
@@ -15,7 +15,7 @@
 	<description>Bank App Spring Boot Project</description>
 
 	<properties>
-		<java.version>1.8</java.version>
+		<java.version>11</java.version>
 	</properties>
 
 	<dependencies>
@@ -49,18 +49,13 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<optional>true</optional>
-		</dependency>
-		<dependency>
-			<groupId>io.springfox</groupId>
-			<artifactId>springfox-swagger2</artifactId>
-			<version>2.9.2</version>
-		</dependency>
-		<dependency>
-			<groupId>io.springfox</groupId>
-			<artifactId>springfox-swagger-ui</artifactId>
-			<version>2.9.2</version>
-		</dependency>		
+		<optional>true</optional>
+	</dependency>
+	<dependency>
+		<groupId>io.springfox</groupId>
+		<artifactId>springfox-boot-starter</artifactId>
+		<version>3.0.0</version>
+	</dependency>		
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>


### PR DESCRIPTION
# Upgrade from Java 8 to Java 11

## Summary
This PR upgrades the BankApp Spring Boot application from Java 8 to Java 11 as requested. The changes include:

- **Java version**: Updated from `1.8` to `11` in pom.xml
- **Spring Boot**: Upgraded from `2.1.4.RELEASE` to `2.3.12.RELEASE` for Java 11 compatibility
- **Swagger/OpenAPI**: Consolidated from separate Springfox 2.x dependencies (`springfox-swagger2` and `springfox-swagger-ui` both at 2.9.2) to `springfox-boot-starter` 3.0.0 for Java 11 compatibility
- **Lombok**: Will automatically update to Java 11-compatible version via Spring Boot parent dependency management

## Review & Testing Checklist for Human

⚠️ **Important**: These changes could NOT be tested locally because the development environment has Java 8 installed, not Java 11. Please verify thoroughly:

- [ ] **Build verification**: Confirm the application compiles successfully with Java 11 (`mvn clean compile`)
- [ ] **Test suite**: Run all tests and verify they pass (`mvn test`)
- [ ] **Swagger UI accessibility**: The Swagger UI URL may have changed with Springfox 3.0.0. Test both:
  - Old URL: `http://localhost:8989/bank-api/swagger-ui.html`
  - New URL: `http://localhost:8989/bank-api/swagger-ui/index.html`
- [ ] **Application runtime**: Start the application (`mvn spring-boot:run`) and verify:
  - Application starts without errors
  - Swagger documentation loads correctly
  - Basic API endpoints work (test a few CRUD operations)
  - H2 console is accessible at `http://localhost:8989/bank-api/h2-console/`
- [ ] **Configuration review**: Check if `ApplicationConfig.java` needs updates for Springfox 3.0.0 compatibility (Springfox 3.x may require different configuration than 2.x)

### Recommended Test Plan
1. Set `JAVA_HOME` to Java 11 JDK
2. Run `mvn clean install` to build and test
3. Start the application with `mvn spring-boot:run`
4. Access Swagger UI and verify API documentation renders correctly
5. Test at least one endpoint from each controller (Customer and Account)
6. Verify H2 console access with credentials: `username=bankapp, password=changeit`

### Notes
- The upgrade from Spring Boot 2.1.4 to 2.3.12 spans several minor versions - while Spring Boot maintains backward compatibility, watch for any deprecation warnings in logs
- Springfox 3.0.0 is a major version upgrade from 2.9.2 and may have breaking changes in configuration
- No Java source code changes were made per requirements, but Swagger configuration (`ApplicationConfig.java`) may need adjustment if issues arise

**Link to Devin run**: https://app.devin.ai/sessions/9fbaf8ef8f6c4ed4996d9eb5c13593bc  
**Requested by**: Stephen Cornwell (@stephencornwell)