### PR TITLE
Component 1: Update Base Configuration for Java 8 to 21 Migration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.4.RELEASE</version>
+		<version>3.3.5</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.coding.exercise</groupId>
@@ -15,7 +15,7 @@
 	<description>Bank App Spring Boot Project</description>
 
 	<properties>
-		<java.version>1.8</java.version>
+		<java.version>21</java.version>
 	</properties>
 
 	<dependencies>
@@ -78,6 +78,15 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>21</source>
+					<target>21</target>
+					<release>21</release>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
# Component 1: Update Base Configuration for Java 8 to 21 Migration

## Summary

This PR implements Component 1 of the Java 8 to 21 migration by updating the core build configuration in `pom.xml`. The changes prepare the project for Java 21 by updating the Java version, upgrading Spring Boot to 3.3.5, and adding explicit Maven compiler configuration.

**Key Changes**:
- Updated `java.version` property from `1.8` to `21`
- Upgraded Spring Boot parent from `2.1.4.RELEASE` to `3.3.5` (major version jump)
- Added `maven-compiler-plugin` with explicit Java 21 source/target/release configuration
- Minor: Updated springfox-swagger-ui version from 2.9.2 to 2.10.0

**Note**: This PR also includes documentation and CI workflow files (README_NEW.md, CONTRIBUTING.md, docs-ci.yml) that were present on the branch from previous work. These are not part of Component 1 but will be merged together.

## Review & Testing Checklist for Human

**⚠️ HIGH RISK - This PR requires careful review and testing**

- [ ] **Verify Java 21 compilation**: The changes couldn't be tested with Java 21 in the dev environment (only Java 8/17 available). You MUST verify the project compiles with Java 21 before merging.

- [ ] **Check for Spring Boot 2 → 3 breaking changes**: Spring Boot 3.x includes major breaking changes (javax → jakarta namespace migration, removed/deprecated APIs). The codebase likely needs additional updates beyond pom.xml changes. Review the [Spring Boot 3.0 Migration Guide](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide).

- [ ] **Verify Swagger/Springfox compatibility**: Springfox may not be compatible with Spring Boot 3.x. Consider migrating to SpringDoc (the recommended alternative for Spring Boot 3). Test that Swagger UI still works at `/bank-api/swagger-ui.html`.

- [ ] **Review documentation files**: The PR includes README_NEW.md, CONTRIBUTING.md, and CI workflows that weren't part of Component 1. Verify these are ready to merge or should be separated into a different PR.

- [ ] **Test the application end-to-end**: After compilation succeeds, run the application and verify:
  - Application starts successfully on port 8989
  - H2 console is accessible
  - API endpoints respond correctly
  - Basic authentication still works

### Notes

- This is Component 1 of the migration and is marked as **critical** - other migration components depend on this being completed first.
- The maven-compiler-plugin configuration uses `<release>21</release>` which is the recommended approach for Java 9+ to ensure cross-compilation compatibility.
- CI checks may fail initially due to Java version mismatches in the CI environment - the CI configuration may need to be updated to use Java 21.

**Link to Devin run**: https://app.devin.ai/sessions/1a6a2c4bf80a48ae9f61be1836a928c3  
**Requested by**: Jaime Mizrachi (jaime@cognition.ai) (@jaime-leo)